### PR TITLE
Fix crash in release-build.

### DIFF
--- a/ReactKitCatalog-iOS/Samples/GestureViewController.swift
+++ b/ReactKitCatalog-iOS/Samples/GestureViewController.swift
@@ -38,6 +38,16 @@ class GestureViewController: UIViewController, UIGestureRecognizerDelegate
         
         // anySignal (concatenating above signal-strings)
         let anySignal = Signal.any(self.signals).map { (values: [NSString??], changedValue: NSString?) -> NSString? in
+            
+            //
+            // WARNING: 2014/12/16
+            //
+            // When release-build, this closure is getting called on MultipleTextFieldViewController's textField input for some reason,
+            // even though this GestureViewController's `viewDidLoad` has never been called.
+            // It seems `Signal.any()` has been treated as sort of singleton object (shared among other viewControllers) on release-build,
+            // which is definitely a Swift compiler's bug because this never happens on debug-build.
+            //
+            
             return "\n".join(values.map { ($0 ?? "")!! as String }.filter { !$0.isEmpty })
         }
         


### PR DESCRIPTION
Fixed a crash bug in release-build. 
But there still seems to have Swift compiler bug when release-building...
(for optimization level `-O` and `-Ounchecked`)
- [x] Fix mysterious nil-coalescing operator `??` crash bug
- [ ] Fix wrong signal's closure being invoked as discussed in [GestureViewController.swift#L42-L49](https://github.com/ReactKit/ReactKitCatalog/blob/e5d509d88ea987da9bfb68ca1048ff16fb27cbf0/ReactKitCatalog-iOS/Samples/GestureViewController.swift#L42-L49) and [ReactiveCocoa/ReactiveCocoa#1632](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/1632) (2015/01/06 still not resolved)

---

1st hint from: https://github.com/ReactKit/ReactKit/commit/36fa3ce05e590ec405db86b37977b5712bba3769#commitcomment-8973134
